### PR TITLE
Fix Markdown linting

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,4 +1,4 @@
 {
-    "MD013/line-length": false,
+    "MD013": false,
     "MD014": false
 }

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,4 +1,4 @@
 {
-    "MD013": false,
-    "MD014": false
+    "line-length": false,
+    "commands-show-output": false
 }


### PR DESCRIPTION
What amounts to a late-night bug, I introduced a line into our Markdown linting configuration that is incorrect: `"MD013/line-length"` does not work.

The obvious solution is to remove the `/line-length` suffix, which makes it work.

But we can do even better: those numbers ("MD013") are totally not intuitive. The labels are, however, and it is totally allowed to use them! So let's use them.