### PR TITLE
Add some branding

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,9 @@
 name: 'Setup Git for Windows SDK'
 description: 'Set up an environment to develop Git for Windows'
 author: 'Johannes Schindelin'
+branding:
+  icon: fast-forward
+  color: blue
 inputs:
   flavor:
     required: false


### PR DESCRIPTION
In preparation for publishing this Action on [the GitHub Marketplace](https://github.com/marketplace), let's [add some branding](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#branding). We use the [fast-forward](https://feathericons.com/?query=fast-forward) icon (it would be nice to use <img alt="the Git for Windows logo" src="https://gitforwindows.org/favicon.ico" width=16 height=16> but that's [impossible for mere mortals](https://github.community/t/can-one-set-a-custom-image-icon-for-a-github-action-or-github-workflow-or-only-github-apps/17513), at least at the moment).