### PR TITLE
ci: use node v12.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,10 @@ jobs:
   build: # make sure build/ci work properly
     runs-on: windows-latest
     steps:
+      - name: Use Node.js v12.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12.x
       - uses: actions/checkout@v2
       - run: npm ci
       - run: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -2025,9 +2025,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "15.14.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.0.tgz",
-      "integrity": "sha512-um/+/ip3QZmwLfIkWZSNtQIJNVAqrJ92OkLMeuZrjZMTAJniI7fh8N8OICyDhAJ2mzgk/fmYFo72jRr5HyZ1EQ=="
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.0.0.tgz",
+      "integrity": "sha512-TmCW5HoZ2o2/z2EYi109jLqIaPIi9y/lc2LmDCWzuCi35bcaQ+OtUh6nwBiFK7SOu25FAU5+YKdqFZUwtqGSdg=="
     },
     "@types/node-fetch": {
       "version": "2.5.10",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@types/jest": "^26.0.23",
-    "@types/node": "^15.14.0",
+    "@types/node": "^16.0.0",
     "@types/unzipper": "^0.10.4",
     "@typescript-eslint/parser": "^4.28.2",
     "@vercel/ncc": "^0.28.6",


### PR DESCRIPTION
This hopefully resolves the problems with "error TS2694: Namespace 'NodeJS' has no exported member 'Global'."