### PR TITLE
Update to `actions/github-script@v7`

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -24,7 +24,7 @@ jobs:
           script: |
             const { execSync } = require('child_process')
 
-            for (const { key_id, raw_key } of (await github.users.listGpgKeysForUser({
+            for (const { key_id, raw_key } of (await github.rest.users.listGpgKeysForUser({
                 username: 'dscho'
             })).data) {
               execSync(`gpg ${raw_key ? '--import' : `--recv-keys ${key_id}`}`,
@@ -73,7 +73,7 @@ jobs:
             const { readFileSync } = require('fs')
 
             const tag_name = readFileSync('tag_name').toString()
-            await github.repos.createRelease({
+            await github.rest.repos.createRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,
               tag_name: tag_name,

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -18,7 +18,7 @@ jobs:
           token: ${{ secrets.PUSH_RELEASE_TRAINS_PAT }}
           fetch-depth: 0
       - name: Import public GPG keys to verify the tag
-        uses: actions/github-script@v3
+        uses: actions/github-script@v7
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
@@ -66,7 +66,7 @@ jobs:
           git cat-file tag "$GITHUB_REF" | sed -e '1,/^$/d' -e '/-----BEGIN PGP SIGNATURE-----/,$d' >body
       - name: Create Release
         if: github.repository_owner == 'git-for-windows'
-        uses: actions/github-script@v3
+        uses: actions/github-script@v7
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |


### PR DESCRIPTION
This imitates what I just did in `get-azure-pipelines-artifact`, and it only affects the `release-tag` workflow (i.e. it does not require a new tag and release).