### PR TITLE
Add `ucrt64` support for `minimal`, `makepkg-git`, and `build-installers` flavors

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -9,19 +9,12 @@ jobs:
       fail-fast: false
       matrix:
         flavor: ['minimal', 'makepkg-git', 'build-installers', 'full']
-        architecture: ['i686', 'x86_64']
+        architecture: ['i686', 'x86_64', 'ucrt64']
         exclude:
           - flavor: minimal
             architecture: i686
           - flavor: makepkg-git
             architecture: i686
-        # `ucrt64` is wired up end-to-end only for `flavor: full`; the
-        # subset flavors depend on follow-up work in `build-extra` and
-        # the `ci-artifacts` pipeline of `git-sdk-64`. Add the one
-        # combination we can meaningfully exercise.
-        include:
-          - flavor: full
-            architecture: ucrt64
     steps:
       - uses: actions/checkout@v6
       - name: run in-place

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,11 +45,15 @@ jobs:
           - architecture: x86_64
             flavor: minimal
             mingw_prefix: /mingw64
-          # `ucrt64` is wired up end-to-end only for `flavor: full` at
-          # this point (the subset flavors depend on follow-up work in
-          # `build-extra` and the `ci-artifacts` pipeline of
-          # `git-sdk-64`), so that is the one combination we can
-          # meaningfully exercise on every PR.
+          - architecture: ucrt64
+            flavor: minimal
+            mingw_prefix: /ucrt64
+          - architecture: ucrt64
+            flavor: makepkg-git
+            mingw_prefix: /ucrt64
+          - architecture: ucrt64
+            flavor: build-installers
+            mingw_prefix: /ucrt64
           - architecture: ucrt64
             flavor: full
             mingw_prefix: /ucrt64

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,28 +112,27 @@ The Action supports four flavors of the SDK:
 The `architecture` input drives both the underlying `git-sdk-*` repo
 and the `MSYSTEM` / bin-path layout inside the SDK:
 
-| `architecture` | repo            | MSYSTEM      | mingw bin path    | notes                                                                                  |
-| -------------- | --------------- | ------------ | ----------------- | -------------------------------------------------------------------------------------- |
-| `i686`         | `git-sdk-32`    | `MINGW32`    | `/mingw32/bin`    | only `build-installers` and `full`                                                     |
-| `x86_64`       | `git-sdk-64`    | `MINGW64`    | `/mingw64/bin`    | the default; fast path available for `minimal`                                         |
-| `aarch64`      | `git-sdk-arm64` | `CLANGARM64` | `/clangarm64/bin` | only `full` for now                                                                    |
-| `ucrt64`       | `git-sdk-64`    | `UCRT64`     | `/ucrt64/bin`     | UCRT64 migration; cloned from the `ucrt64` branch of `git-sdk-64`; only `full` for now |
+| `architecture` | repo            | MSYSTEM      | mingw bin path    | notes                                                             |
+| -------------- | --------------- | ------------ | ----------------- | ----------------------------------------------------------------- |
+| `i686`         | `git-sdk-32`    | `MINGW32`    | `/mingw32/bin`    | only `build-installers` and `full`                                |
+| `x86_64`       | `git-sdk-64`    | `MINGW64`    | `/mingw64/bin`    | the default; fast path available for `minimal`                    |
+| `aarch64`      | `git-sdk-arm64` | `CLANGARM64` | `/clangarm64/bin` | only `full` for now                                               |
+| `ucrt64`       | `git-sdk-64`    | `UCRT64`     | `/ucrt64/bin`     | UCRT64 migration; cloned from the `ucrt64` branch of `git-sdk-64` |
 
 The `ucrt64` axis is part of the larger UCRT64 migration tracked in
 https://github.com/git-for-windows/git-sdk-64/pull/117 and its
 follow-up comment
 https://github.com/git-for-windows/git-sdk-64/pull/117#issuecomment-4642726384.
 It shares the `git-sdk-64` repository with `x86_64` but is materialised
-from a different long-lived branch, so caches and on-disk directories
-must stay distinct (the artifact name is `git-sdk-ucrt64-<flavor>`
-rather than `git-sdk-64-<flavor>`). The `ci-artifacts` release of
-`git-sdk-64` contains no UCRT64 asset, so the CI-artifacts fast path
-is forcibly skipped for this axis; every flavor takes the
-`getViaGit` path. `build-extra`'s `please.sh create-sdk-artifact` does
-not yet understand `--architecture=ucrt64` either, so right now only
-`flavor: full` (which goes straight through `git worktree add`)
-produces a working SDK. The non-`full` flavors will start working once
-`build-extra` and the `ci-artifacts` pipeline catch up.
+from a separate transitional `ucrt64` branch (which will eventually
+replace `main`), so caches and on-disk directories must stay distinct
+between the two variants (the artifact name is
+`git-sdk-ucrt64-<flavor>` rather than `git-sdk-64-<flavor>`). The
+`ci-artifacts` release of `git-sdk-64` contains no UCRT64 asset, so
+the CI-artifacts fast path is forcibly skipped for this axis; every
+flavor takes the `getViaGit` path, with `please.sh create-sdk-artifact
+--architecture=ucrt64` carving the subset flavors out of the full SDK
+clone exactly as it does for the other architectures.
 
 ## Relationship to other Git for Windows repositories
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Git for Windows SDK comes in variants targeting `x86_64` (AKA "64-bit"), `i686` 
 
 Please note that only the `build-installers` and the `full` flavors are available for `i686`.
 
-In addition, the `ucrt64` value selects the UCRT64 variant of `git-sdk-64`. While the [migration from MINGW64 to UCRT64](https://github.com/git-for-windows/git-sdk-64/pull/117) is in progress, this variant lives on a transitional `ucrt64` branch of `git-sdk-64`; once the migration concludes, that branch will replace `main`, at which point `architecture: x86_64` will itself produce a UCRT64 SDK and `ucrt64` becomes a synonym. Until then, this axis runs under `MSYSTEM=UCRT64` with `/ucrt64/bin` on PATH, uses an output directory and cache key that are distinct from `x86_64` so the two variants do not collide on the same runner, and only supports `flavor: full`.
+In addition, the `ucrt64` value selects the UCRT64 variant of `git-sdk-64`. While the [migration from MINGW64 to UCRT64](https://github.com/git-for-windows/git-sdk-64/pull/117) is in progress, this variant lives on a transitional `ucrt64` branch of `git-sdk-64`; once the migration concludes, that branch will replace `main`, at which point `architecture: x86_64` will itself produce a UCRT64 SDK and `ucrt64` becomes a synonym. Until then, this axis runs under `MSYSTEM=UCRT64` with `/ucrt64/bin` on PATH and uses an output directory and cache key that are distinct from `x86_64` so the two variants do not collide on the same runner.
 
 ### Verbosity
 

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,6 @@ inputs:
       MINGW64-to-UCRT64 migration is in progress it is cloned from a
       transitional "ucrt64" branch that will eventually replace "main",
       at which point "x86_64" itself will materialise a UCRT64 SDK.
-      Only the "full" flavor is supported on the "ucrt64" axis for now.
     default: 'x86_64'
   msys:
     required: false


### PR DESCRIPTION
Follow-up to https://github.com/git-for-windows/setup-git-for-windows-sdk/pull/1361, which added the `ucrt64` axis but only for `flavor: full`. This PR extends that to the `minimal`, `makepkg-git`, and `build-installers` flavors so the `ucrt64` axis is on equal footing with the others.

The Action itself doesn't need new source code for this; it just needed `please.sh create-sdk-artifact --architecture=ucrt64` to be a working invocation, which is what https://github.com/git-for-windows/build-extra/pull/710 adds. So the diff here is documentation hygiene (removing the "only `full` for now" caveats) and matrix extensions (so the new combinations are exercised both on every PR and in the manual all-flavors run). The CI-artifacts fast path stays suppressed for `ucrt64` until upstream grows a UCRT64 asset; that is a separate concern.
